### PR TITLE
Run e-reset at boot to avoid crash if reading the CONFIG register

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ echo 'source ${EPIPHANY_HOME}/setup.csh' >> ${HOME}/.cshrc
 echo 'EPIPHANY_HOME=/opt/adapteva/esdk' >> ${HOME}/.bashrc
 echo '. ${EPIPHANY_HOME}/setup.sh' >> ${HOME}/.bashrc
 ```    
+Initialize the chip at boot, in `/etc/rc.local` add the following lines before `exit 0`:
+```
+export EPIPHANY_HOME=/opt/adapteva/esdk
+export EPIPHANY_HDF=$EPIPHANY_HOME/bsps/current/platform.hdf
+export LD_LIBRARY_PATH=$EPIPHANY_HOME/tools/host/lib
+export PATH=$EPIPHANY_HOME/tools/host/bin:$EPIPHANY_HOME/tools/e-gnu/bin:$PATH
+e-reset
+```
 
 ### 22. Setup COPRTHR
 


### PR DESCRIPTION
before setting it

I've written a program that reads the registers like e-dump-regs does, and the machine crashes if I run it before it has been reset at least once.

I prefer running e-reset once at boot because I don't want to interfere with any running programs just to read the registers.